### PR TITLE
Include tailing colons to link target.

### DIFF
--- a/etc/linuxmuster-client/post-mount.d/008-links
+++ b/etc/linuxmuster-client/post-mount.d/008-links
@@ -50,7 +50,7 @@ for NACHEINANDER in $LINKS; do
  
  SERVER=`echo $NACHEINANDER | cut -d ":" -f 1`
  
- LOKAL=`echo $NACHEINANDER | cut -d ":" -f 2`
+ LOKAL=`echo $NACHEINANDER | cut -d ":" -f 2-99`
  
  # Wenn Ziel auf Server NICHT vorhanden, 
  # (weder als Verzeichnis -d noch als Datei -f)


### PR DESCRIPTION
Allows configuration like this:

```
HOMEDIR/.wine/drive_c:HOMEDIR/.wine/dosdevices/c:
/:HOMEDIR/.wine/dosdevices/z:
```

in

```
/etc/linuxmuster-client/profile/links.conf
```
